### PR TITLE
fix: removing raop.conf from /usr/

### DIFF
--- a/build_files/t2-enablement.sh
+++ b/build_files/t2-enablement.sh
@@ -34,6 +34,7 @@ dnf5 -y --repo=copr:copr.fedorainfracloud.org:sharpenedblade:t2linux install ker
 #    kernel-tools kernel-tools-libs \
 
 dnf5 -y install t2fanrd t2linux-audio
+rm -f /usr/share/pipewire/pipewire.conf.d/raop.conf
 
 # remove packages from fedora image macs don't need
 dnf5 -y remove tiwilink-firmware nxpwireless-firmware nvidia-gpu-firmware mt7xxx-firmware iwlegacy-firmware \


### PR DESCRIPTION
since you can't override arrays in pipewire conf (they append), we need to remove this from /usr/ since end users can't (immutable /usr/). Instead we'll have instructions for adding raop to /etc/pipewire/ or ~/.config/pipewire/ if users would like to have pipewire discovering airplay devices