### PR TITLE
Add Secureblue

### DIFF
--- a/.github/workflows/build-image-kinoite-hardened.yml
+++ b/.github/workflows/build-image-kinoite-hardened.yml
@@ -1,0 +1,126 @@
+---
+name: Build Image - Kinoite Hardened
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "35 10 * * *"
+  workflow_dispatch:
+
+env:
+  IMAGE_DESC: "T2-Atomic Kinoite Hardened (SecureBlue)"
+  IMAGE_KEYWORDS: "bootc,secureblue,t2,hardened"
+  IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"
+  IMAGE_NAME: "${{ github.event.repository.name }}-kinoite-hardened"
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
+  DEFAULT_TAG: "latest"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ inputs.brand_name}}-${{ inputs.stream_name }}
+  cancel-in-progress: true
+
+jobs:
+  build_push:
+    name: Build and push image
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Prepare environment
+        run: |
+          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> ${GITHUB_ENV}
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+
+      - name: Mount BTRFS for podman storage
+        uses: ublue-os/container-storage-action@main
+
+      - name: Get current date
+        id: date
+        run: |
+          echo "date=$(date -u +%Y\-%m\-%d\T%H\:%M\:%S\Z)" >> $GITHUB_OUTPUT
+
+      - name: Image Metadata
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        id: metadata
+        with:
+          tags: |
+            type=raw,value=${{ env.DEFAULT_TAG }}
+            type=raw,value=${{ env.DEFAULT_TAG }}.{{date 'YYYYMMDD'}}
+            type=raw,value={{date 'YYYYMMDD'}}
+            type=sha,enable=${{ github.event_name == 'pull_request' }}
+            type=ref,event=pr
+          labels: |
+            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/refs/heads/main/README.md
+            org.opencontainers.image.created=${{ steps.date.outputs.date }}
+            org.opencontainers.image.description=${{ env.IMAGE_DESC }}
+            org.opencontainers.image.documentation=https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/refs/heads/main/README.md
+            org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/blob/main/Containerfile
+            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+            org.opencontainers.image.vendor=${{ github.repository_owner }}
+            org.opencontainers.image.version=${{ env.DEFAULT_TAG }}.{{date 'YYYYMMDD'}}
+            io.artifacthub.package.deprecated=false
+            io.artifacthub.package.keywords=${{ env.IMAGE_KEYWORDS }}
+            io.artifacthub.package.license=Apache-2.0
+            io.artifacthub.package.logo-url=${{ env.IMAGE_LOGO_URL }}
+            io.artifacthub.package.prerelease=false
+            containers.bootc=1
+          sep-tags: " "
+          sep-annotations: " "
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
+        with:
+          containerfiles: |
+            ./variants/t2-kinoite-hardened/Containerfile
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          oci: false
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push To GHCR
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        id: push
+        env:
+          REGISTRY_USER: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ github.token }}
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+
+      - name: Sign container image
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
+          for tag in ${{ steps.metadata.outputs.tags }}; do
+            cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_FULL:$tag
+          done
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/build_files/t2-enablement.sh
+++ b/build_files/t2-enablement.sh
@@ -18,7 +18,8 @@ set -ouex pipefail
 # Disable COPRs so they don't end up enabled on the final image:
 # dnf5 -y copr disable ublue-os/
 dnf5 -y install dnf5-plugins python3-jsonschema
-dnf5 -y copr enable sharpenedblade/t2linux
+COPR_CHROOT="fedora-$(rpm -E %fedora)-$(uname -m)"
+dnf5 -y copr enable sharpenedblade/t2linux "$COPR_CHROOT"
 dnf5 -y remove kernel-uki-virt kmod-framework-laptop
 #dnf5 -y remove kernel-uki-virt kernel-tools kernel-tools-libs kernel-modules-extra kernel-headers
 #dnf5 -y versionlock delete kernel kernel-core kernel-modules \
@@ -48,16 +49,11 @@ dnf5 -y copr disable sharpenedblade/t2linux
 # and cli apps to access hardware sensors
 dnf5 install -y lm_sensors sg3_utils wodim xorriso radeontop
 
-# install IWD and radio software
-# iwd as backend seems to work better than wpa_supplicant on this hardware
-dnf5 swap -y wpa_supplicant iwd
-cat >> /etc/NetworkManager/conf.d/iwd.conf << EOF
-[device]
-wifi.backend=iwd
-EOF
-
 mkdir -p /lib/firmware/brcm
 tar -xf /ctx/common/radio.tar -C /lib/firmware/brcm
+
+curl -sL https://github.com/AdityaGarg8/Apple-Firmware/archive/refs/heads/main.tar.gz | \
+  tar xz --strip-components=4 -C /lib/firmware/brcm --wildcards '*/brcmfmac4355*'
 
 # applying some T2 customizations
 systemctl mask suspend.target

--- a/variants/t2-kinoite-hardened/Containerfile
+++ b/variants/t2-kinoite-hardened/Containerfile
@@ -1,0 +1,38 @@
+# Allow build scripts to be referenced without being copied into the final image
+FROM scratch AS ctx
+COPY build_files /
+
+# Base Image
+FROM ghcr.io/secureblue/kinoite-main-hardened:latest
+
+## Other possible base images include:
+# FROM ghcr.io/ublue-os/bazzite:latest
+# FROM ghcr.io/ublue-os/bluefin-nvidia:stable
+#
+# ... and so on, here are more base images
+# Universal Blue Images: https://github.com/orgs/ublue-os/packages
+# Fedora base image: quay.io/fedora/fedora-bootc:41
+# CentOS base images: quay.io/centos-bootc/centos-bootc:stream10
+
+### MODIFICATIONS
+## make modifications desired in your image and install packages by modifying the build.sh script
+## the following RUN directive does all the things required to run "build.sh" as recommended.
+
+# some T2 tweaks require etc drop-ins
+COPY --chmod=0644 /variants/common/etc/ /etc/
+
+RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache \
+    --mount=type=cache,dst=/var/log \
+    --mount=type=tmpfs,dst=/var \
+    /ctx/t2-enablement.sh && \
+    rm -rf /tmp/* /var/tmp/* && \
+    ostree container commit
+
+### LINTING
+## Verify final image and contents are correct.
+RUN bootc container lint
+
+# Define required labels for this bootc image to be recognized as such.
+LABEL containers.bootc 1
+LABEL ostree.bootable 1

--- a/variants/t2-kinoite-hardened/Containerfile
+++ b/variants/t2-kinoite-hardened/Containerfile
@@ -21,6 +21,9 @@ FROM ghcr.io/secureblue/kinoite-main-hardened:latest
 # some T2 tweaks require etc drop-ins
 COPY --chmod=0644 /variants/common/etc/ /etc/
 
+# Must be added before T2 kernel install so dracut includes it in the initramfs
+RUN echo 'install_items+=" /usr/lib64/libno_rlimit_as.so /usr/lib/systemd/systemd-sysroot-fstab-check /usr/lib/systemd/system-generators/systemd-fstab-generator "' > /etc/dracut.conf.d/99-secureblue-initramfs.conf
+
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
@@ -28,6 +31,11 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     /ctx/t2-enablement.sh && \
     rm -rf /tmp/* /var/tmp/* && \
     ostree container commit
+
+ARG USER=secureblue
+ARG PASSWORD=secureblue
+RUN useradd -m -G wheel $USER && echo "$USER:$PASSWORD" | chpasswd
+RUN systemctl set-default graphical.target
 
 ### LINTING
 ## Verify final image and contents are correct.


### PR DESCRIPTION
Took awhile to add this since secureblue disables a lot of features by default, but here ya go

- Use wpa_supplicant, since [iwd doesn't work on the hardened kernel](https://secureblue.dev/faq#crypto-api) (missing crypto APIs)
- add dracut items for boot (systemd-sysroot-fstab-check, systemd-fstab-generator)
- Wasn't able to manually download wifi/bluetooth firmware after installation and didn't have the patience to figure out why, so the ISO build pulls in BCM4355 wifi firmware (We can remove if it's not your ideal implementation)
- set graphical.target, secureblue defaults to multi-user (I wasn't able to get it to boot into the graphical environment immediately, I had to boot in from the command line after logging in)
- default user (user:secureblue/password:secureblue) since root is locked and anaconda doesn't create one, configurable with build args