### PR TITLE
fix: updating the dracut config to restore early boot keyboard use

### DIFF
--- a/build_files/apps-kansei.sh
+++ b/build_files/apps-kansei.sh
@@ -15,7 +15,7 @@ dnf5 -y copr enable erikreider/SwayNotificationCenter
 dnf5 -y copr enable alebastr/sway-extras
 dnf5 -y copr enable shdwchn10/AllTheTools
 dnf5 -y copr enable yalter/niri
-dnf5 -y copr enable solopasha/hyprland
+dnf5 -y copr enable eli-xciv/hyprland
 dnf5 -y copr enable alternateved/keyd
 
 #### greeters, login things

--- a/build_files/apps-kansei.sh
+++ b/build_files/apps-kansei.sh
@@ -119,6 +119,6 @@ dnf5 -y copr disable alebastr/sway-extras
 dnf5 -y copr disable shdwchn10/AllTheTools
 dnf5 -y copr disable yalter/niri
 dnf5 -y copr disable kylegospo/webapp-manager
-dnf5 -y copr disable solopasha/hyprland
+dnf5 -y copr disable eli-xciv/hyprland
 dnf5 -y copr disable alternateved/keyd
 dnf5 -y copr disable ublue-os/packages

--- a/variants/common/etc/dracut.conf.d/t2-bce.conf
+++ b/variants/common/etc/dracut.conf.d/t2-bce.conf
@@ -1,2 +1,2 @@
-#load apple-bce early so keyboard works for LUKS and early boot
-force_drivers+=" apple_bce snd snd-pcm "
+#load t2bce early so keyboard works for LUKS and early boot
+force_drivers+=" t2bce_dma t2bce_core t2bce_vhci "


### PR DESCRIPTION
Simple change to switch dracut setup for early boot keyboard (for LUKS etc) from 'apple-bce' to 't2bce'